### PR TITLE
MCC-226902 - update gitignore to remove unzipped prebuilts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,5 @@ resources/tiny_mce
 test/interactive
 debug/
 
-
-
-
-
-
+# Unzipped prebuilts
+prebuilt/lib/ios/*.a


### PR DESCRIPTION
This PR updates the .gitignore to include the unzipped prebuilts, so that we don't see our submodules in our `git status` output.
